### PR TITLE
Feature/invite companies endpoint

### DIFF
--- a/api/src/controllers/inviteCompaniesController.js
+++ b/api/src/controllers/inviteCompaniesController.js
@@ -1,0 +1,27 @@
+const { Companies, Users } = require('../db');
+const { sendInviteCompanies } = require('../services/resend');
+
+const postInviteCompanies = async (body) => {
+  const { companyId, emails } = body;
+  if (!companyId) {
+    const error = new Error('Missing sender company ID.');
+    error.status = 400;
+    throw error;
+  }
+  if (!emails) {
+    const error = new Error('Missing receiver emails.');
+    error.status = 400;
+    throw error;
+  }
+  const foundCompany = await Companies.findByPk(companyId, {
+    include: [{ model: Users }],
+  });
+  const companyName = foundCompany.name;
+  console.log(companyName);
+  const resendResponse = await sendInviteCompanies(emails, companyName);
+  return resendResponse;
+};
+
+module.exports = {
+  postInviteCompanies,
+};

--- a/api/src/handlers/inviteCompaniesHandler.js
+++ b/api/src/handlers/inviteCompaniesHandler.js
@@ -1,0 +1,15 @@
+const { postInviteCompanies } = require('../controllers/inviteCompaniesController');
+
+const postInviteCompaniesHandler = async (req, res) => {
+  try {
+    const body = req.body;
+    const invitationSent = await postInviteCompanies(body);
+    res.status(201).json(invitationSent);
+  } catch (error) {
+    res.status(error.status || 500).json({ error: error.message });
+  }
+};
+
+module.exports = {
+  postInviteCompaniesHandler,
+};

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -15,6 +15,7 @@ const proposalsRouter = require('./resources/proposalsRouter');
 const documentsRouter = require('./resources/documentsRouter');
 const bankAccountsRouter = require('./resources/bankAccountsRouter');
 const financeProductsRouter = require('./resources/financeProductsRouter');
+const inviteCompaniesRouter = require('./resources/inviteCompaniesRouter');
 
 const router = Router();
 
@@ -36,5 +37,7 @@ router.use('/proposals', proposalsRouter);
 router.use('/documents', documentsRouter);
 router.use('/bankAccounts', bankAccountsRouter);
 router.use('/financeProducts', financeProductsRouter);
+
+router.use('/inviteCompanies', inviteCompaniesRouter);
 
 module.exports = router;

--- a/api/src/routes/resources/inviteCompaniesRouter.js
+++ b/api/src/routes/resources/inviteCompaniesRouter.js
@@ -1,0 +1,8 @@
+const { Router } = require('express');
+const { postInviteCompaniesHandler } = require('../../handlers/inviteCompaniesHandler');
+
+const inviteCompaniesRouter = Router();
+
+inviteCompaniesRouter.post('/', postInviteCompaniesHandler);
+
+module.exports = inviteCompaniesRouter;

--- a/api/src/services/emailTemplates.js
+++ b/api/src/services/emailTemplates.js
@@ -118,6 +118,26 @@ const generateCompanyEmailFinanceProductDeclined = (companyOwnerName, companyNam
   return html;
 };
 
+const generateSendInviteCompanies = (companyName) => {
+  const html = `
+  <body>
+    <p><b>Hola!</b></p>
+    <p>La empresa ${companyName} te ha invitado a unirte a Energialy!</p>
+    <p>En Energialy contratás y sos contratado: </p>
+    <p>Creá Licitaciones y contratá a proveedores de servicios, sin cargo. </p>
+    <p>Participá y enviá tu propuesta en Licitaciones de otras empresas. </p>
+    <p>También accedés a las soluciones financieras de Banco de Comercio para que tu Pyme y tus Proyectos sigan creciendo: </p>
+    <p>PRÉSTAMOS </p>
+    <p>FACTURAS DE CRÉDITO ELECTRÓNICAS </p>
+    <p>E-CHEQS | CHEQUES </p>
+    <p>COMEX </p>
+    <p>Energialy es la plataforma para integrar a la Cadena de Valor, gestionar contrataciones entre Pymes y acceder a financiamiento. </p>
+    <p>Ingresá ahora y creá tu Cuenta gratis! </p>
+  </body>
+  `;
+  return html;
+};
+
 module.exports = {
   generateEmployerEmailProposalReceived,
   generateSupplierEmailProposalAccepted,
@@ -128,4 +148,5 @@ module.exports = {
   generateCompanyEmailBankAccountRequireChanges,
   generateCompanyEmailFinanceProductAccepted,
   generateCompanyEmailFinanceProductDeclined,
+  generateSendInviteCompanies,
 };

--- a/api/src/services/resend.js
+++ b/api/src/services/resend.js
@@ -9,6 +9,7 @@ const {
   generateCompanyEmailBankAccountRequireChanges,
   generateCompanyEmailFinanceProductAccepted,
   generateCompanyEmailFinanceProductDeclined,
+  generateSendInviteCompanies,
 } = require('./emailTemplates');
 
 const sendEmployerEmailProposalReceived = async (receiver, employerName, supplierCompanyName, tenderTitle, proposalAmount, proposalDuration) => {
@@ -110,6 +111,17 @@ const sendCompanyEmailFinanceProductDeclined = async (receiver, companyOwnerName
   console.log(response);
 };
 
+const sendInviteCompanies = async (receiver, companyName) => {
+  const resend = new Resend(process.env.RESEND_API_KEY);
+  const response = await resend.emails.send({
+    from: 'Energialy <energialy@resend.dev>',
+    to: receiver,
+    subject: '¡Te invitaron a unirte a Energialy!',
+    html: generateSendInviteCompanies(companyName),
+  });
+  console.log(response);
+};
+
 module.exports = {
   sendEmployerEmailProposalReceived,
   sendSupplierEmailProposalAccepted,
@@ -120,4 +132,5 @@ module.exports = {
   sendCompanyEmailBankAccountRequireChanges,
   sendCompanyEmailFinanceProductAccepted,
   sendCompanyEmailFinanceProductDeclined,
+  sendInviteCompanies,
 };


### PR DESCRIPTION
Se creó nuevo endpoint POST a /inviteCompanies para que una empresa pueda mandar un email de invitación a un arreglo de emails.
La request debe recibir por body param un string `companyId` con el ID de la company que quiere invitar y un arreglo de strings `emails` con los emails a enviar.
Body de ejemplo:
```
{
    "companyId": "d4f607e4-454a-4bc0-8174-64835dc93364",
    "emails": ["email1@gmail.com", "email2@gmail.com", "email3@gmail.com"]
}
```