### PR TITLE
Managing env variables

### DIFF
--- a/api/src/db.js
+++ b/api/src/db.js
@@ -2,9 +2,9 @@ require('dotenv').config();
 const { Sequelize } = require('sequelize');
 const fs = require('fs');
 const path = require('path');
-const { POSTGRES_URL } = process.env;
+const { POSTGRES_URL, SSL_MODE } = process.env;
 
-const sequelize = new Sequelize(`${POSTGRES_URL}?sslmode=require`, {
+const sequelize = new Sequelize(`${POSTGRES_URL}${SSL_MODE}`, {
   logging: false, // set to console.log to see the raw SQL queries
   native: false, // lets Sequelize know we can use pg-native for ~30% more speed
   dialectModule: require('pg'),

--- a/api/src/server.js
+++ b/api/src/server.js
@@ -4,6 +4,7 @@ const bodyParser = require('body-parser');
 const morgan = require('morgan');
 const cors = require('cors');
 const routes = require('./routes/index.js');
+const { CORS_ORIGIN_URL } = process.env;
 
 const app = express();
 
@@ -15,7 +16,7 @@ app.use(bodyParser.json({ limit: '50mb' }));
 app.use(cookieParser());
 app.use(morgan('dev'));
 app.use((req, res, next) => {
-  res.header('Access-Control-Allow-Origin', 'https://energialy.vercel.app'); // update to match the domain you will make the request from
+  res.header('Access-Control-Allow-Origin', CORS_ORIGIN_URL); // update to match the domain you will make the request from
   res.header('Access-Control-Allow-Credentials', 'true');
   res.header('Access-Control-Allow-Headers', 'Origin, X-Requested-With, Content-Type, Accept');
   res.header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, DELETE');


### PR DESCRIPTION
@fspiritosi @gonzasuarez96  Se agregaron dos env variables en el backend:

- `CORS_ORIGIN_URL`: siendo `localhost:3001` para levantar el server en el entorno local y `energialy.vercel.app` para production
- `SSL_MODE`: siendo un string vacío para levantar el server en el entorno local y `?sslmode=require` en production